### PR TITLE
Fixed superfluous response.WriteHeader call

### DIFF
--- a/feed.go
+++ b/feed.go
@@ -60,7 +60,6 @@ func feedHandler(res http.ResponseWriter, req *http.Request) {
 	}
 
 	fmt.Fprint(res, atom)
-	res.WriteHeader(http.StatusOK)
 }
 
 // GetStatusCode GetStatusCode returns status code in message

--- a/static.go
+++ b/static.go
@@ -27,5 +27,4 @@ func renderFile(res http.ResponseWriter, filename string) {
 
 	content := string(b)
 	fmt.Fprint(res, content)
-	res.WriteHeader(http.StatusOK)
 }


### PR DESCRIPTION
```
http: superfluous response.WriteHeader call from github.com/getsentry/sentry-go/http.(*responseWriter).WriteHeader (sentryhttp.go:75)
```