### PR TITLE
Set `no-referrer` to `index.html`

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta name="referrer" content="no-referrer">
   <title>feed_squeezer</title>
 
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">


### PR DESCRIPTION
Currently, when we click on the GitHub repo link at the bottom of the form, a referrer is sent to GitHub.

![image](https://github.com/sue445/feed_squeezer/assets/608755/88662c55-6def-4679-9e90-14d7d284c8b2)

This information is currently displayed like this in my repository.

![image](https://github.com/sue445/feed_squeezer/assets/608755/0c5a37ea-8d97-4e57-8225-617bfbbbe06e)

This tool is hosted by the user at an arbitrary URL.

Even if I am the only one who can see it, it is not a very desirable behavior.

So I have stopped sending referrer.