### PR TITLE
Fixed Version and Revision are empty in binary download from releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,6 +22,8 @@ builds:
       - linux
       - windows
       - darwin
+    ldflags:
+      - -s -w -X "main.Version={{.Tag}}" -X "main.Revision={{.ShortCommit}}"
 
 archives:
   - format: tar.gz


### PR DESCRIPTION
```
$ ./feed_squeezer -version
feed_squeezer  (revision )
```