### PR TITLE
docs: Use ServiceAccount for CloudRun service

### DIFF
--- a/_examples/gcp_cloud_run_terraform/cloud_run.tf
+++ b/_examples/gcp_cloud_run_terraform/cloud_run.tf
@@ -1,5 +1,5 @@
 resource "google_cloud_run_service" "feed_squeezer" {
-  name     = var.name
+  name     = var.service_name
   location = var.location
 
   template {
@@ -11,6 +11,8 @@ resource "google_cloud_run_service" "feed_squeezer" {
     }
 
     spec {
+      service_account_name = google_service_account.feed_squeezer.email
+
       containers {
         # c.f. https://console.cloud.google.com/artifacts/docker/feed-squeezer/us/feed-squeezer/app
         image = "us-docker.pkg.dev/feed-squeezer/feed-squeezer/app:${var.tag}"

--- a/_examples/gcp_cloud_run_terraform/service_account.tf
+++ b/_examples/gcp_cloud_run_terraform/service_account.tf
@@ -1,0 +1,3 @@
+resource "google_service_account" "feed_squeezer" {
+  account_id = var.service_account_name
+}

--- a/_examples/gcp_cloud_run_terraform/terraform.tfvars
+++ b/_examples/gcp_cloud_run_terraform/terraform.tfvars
@@ -1,4 +1,4 @@
-name = "feed-squeezer"
+service_name = "feed-squeezer"
 
 location = "us-central1"
 
@@ -9,3 +9,5 @@ sentry_dsn = ""
 min_instance_count = 0
 
 max_instance_count = 1
+
+service_account_name = "feed-squeezer"

--- a/_examples/gcp_cloud_run_terraform/variables.tf
+++ b/_examples/gcp_cloud_run_terraform/variables.tf
@@ -1,6 +1,6 @@
-variable "name" {
+variable "service_name" {
   type        = string
-  description = "Cloud Run app name"
+  description = "Cloud Run service name"
   default     = "feed-squeezer"
 }
 
@@ -33,4 +33,10 @@ variable "max_instance_count" {
   type        = number
   description = "max instances"
   default     = 1
+}
+
+variable "service_account_name" {
+  type        = string
+  description = "ServiceAccount name"
+  default     = "feed-squeezer"
 }


### PR DESCRIPTION
CloudRun's default ServiceAccount ( `PROJECT_NUMBER-compute@developer.gserviceaccount.com` ) has very broad permissions