### PR TITLE
ci: jandelgado/gcov2lcov-action is deprecated

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,17 +34,12 @@ jobs:
       - run: make test
       - run: make testrace
 
-      - name: Convert coverage to lcov
-        uses: jandelgado/gcov2lcov-action@v1
-        with:
-          infile: coverage.out
-          outfile: coverage.lcov
-
       - name: Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: coverage.lcov
+          file: coverage.out
+          format: golang
 
       - name: Slack Notification (not success)
         uses: act10ns/slack@v2


### PR DESCRIPTION
ref. https://github.com/jandelgado/gcov2lcov-action/commit/9a62e299656d843ed3b0cb689bdef39af0aca654