### PR TITLE
chore: Fix deprecation warning in goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,7 +26,7 @@ builds:
       - -s -w -X "main.Version={{.Tag}}" -X "main.Revision={{.ShortCommit}}"
 
 archives:
-  - format: tar.gz
+  - formats: ['tar.gz']
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -38,7 +38,7 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats: ['zip']
 
 changelog:
   disable: true


### PR DESCRIPTION
c.f. https://goreleaser.com/deprecations/#archivesformat