### PR TITLE
[CVE-2026-25680][CVE-2026-25681][CVE-2026-27136][CVE-2026-42502][CVE-2026-42506] Upgrade to golang.org/x/net v0.55.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
-	golang.org/x/net v0.45.0 // indirect
-	golang.org/x/sys v0.36.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
+	golang.org/x/sys v0.45.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210916014120-12bc252f5db8/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.45.0 h1:RLBg5JKixCy82FtLJpeNlVM0nrSqpCRYzVU1n8kj0tM=
-golang.org/x/net v0.45.0/go.mod h1:ECOoLqd5U3Lhyeyo/QDCEVQ4sNgYsqvCZ722XogGieY=
+golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
+golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -91,8 +91,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
-golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=


### PR DESCRIPTION
* https://pkg.go.dev/vuln/GO-2026-5025 (CVE-2026-42506)
* https://pkg.go.dev/vuln/GO-2026-5027 (CVE-2026-42502)
* https://pkg.go.dev/vuln/GO-2026-5028 (CVE-2026-25680)
* https://pkg.go.dev/vuln/GO-2026-5029 (CVE-2026-25681)
* https://pkg.go.dev/vuln/GO-2026-5030 (CVE-2026-27136)

```
Run govulncheck -C . -format text ./...
=== Symbol Results ===

Vulnerability #1: GO-2026-5030
    Invoking duplicate attributes can cause XSS in golang.org/x/net/html
  More info: https://pkg.go.dev/vuln/GO-2026-5030
  Module: golang.org/x/net
    Found in: golang.org/x/net@v0.45.0
    Fixed in: golang.org/x/net@v0.55.0
    Example traces found:
Error:       #1: feed.go:106:23: feed_squeezer.GenerateSqueezedAtom calls gofeed.Parser.Parse, which eventually calls html.Parse

Vulnerability #2: GO-2026-5029
    Invoking incorrect handling of character references in DOCTYPE nodes in
    golang.org/x/net/html
  More info: https://pkg.go.dev/vuln/GO-2026-5029
  Module: golang.org/x/net
    Found in: golang.org/x/net@v0.45.0
    Fixed in: golang.org/x/net@v0.55.0
    Example traces found:
Error:       #1: feed.go:106:23: feed_squeezer.GenerateSqueezedAtom calls gofeed.Parser.Parse, which eventually calls html.Parse

Vulnerability #3: GO-2026-5028
    Invoking denial of service when parsing arbitrary HTML in
    golang.org/x/net/html
  More info: https://pkg.go.dev/vuln/GO-2026-5028
  Module: golang.org/x/net
    Found in: golang.org/x/net@v0.45.0
    Fixed in: golang.org/x/net@v0.55.0
    Example traces found:
Error:       #1: feed.go:106:23: feed_squeezer.GenerateSqueezedAtom calls gofeed.Parser.Parse, which eventually calls html.Parse

Vulnerability #4: GO-2026-5027
    Invoking incorrect handling of HTML elements in foreign content in
    golang.org/x/net/html
  More info: https://pkg.go.dev/vuln/GO-2026-5027
  Module: golang.org/x/net
    Found in: golang.org/x/net@v0.45.0
    Fixed in: golang.org/x/net@v0.55.0
    Example traces found:
Error:       #1: feed.go:106:23: feed_squeezer.GenerateSqueezedAtom calls gofeed.Parser.Parse, which eventually calls html.Parse

Vulnerability #5: GO-2026-5025
    Invoking incorrect handling of namespaced elements in foreign content in
    golang.org/x/net/html
  More info: https://pkg.go.dev/vuln/GO-2026-5025
  Module: golang.org/x/net
    Found in: golang.org/x/net@v0.45.0
    Fixed in: golang.org/x/net@v0.55.0
    Example traces found:
Error:       #1: feed.go:106:23: feed_squeezer.GenerateSqueezedAtom calls gofeed.Parser.Parse, which eventually calls html.Parse
```

https://github.com/sue445/feed_squeezer/actions/runs/26723082845/job/78753567024